### PR TITLE
Fix Error: Optional not defined

### DIFF
--- a/decoding_tree_sketching/utils/eval_utils.py
+++ b/decoding_tree_sketching/utils/eval_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from typing import Optional
 
 def read_jsonl(path: str):
     with open(path) as fh:


### PR DESCRIPTION
This PR fixes the NameError that occurs when running inference_example.py:

NameError: name 'Optional' is not defined

Thank for your outstanding work.